### PR TITLE
Added a way to force re-caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,18 @@ Custom features
 #### Level-party
 The plugin uses the [level-party](https://github.com/substack/level-party) module to get over the level multi-process restrictions.
 
+#### Refresh Cache
+Any request submitted from localhost with the user-agent of "RefreshCache" will force the requested page to be re-cached.
+
+Example:
+```
+curl --retry 5 -m 1 -k -f -A "RefreshCache" "http://example.com"
+```
+
 #### Freshness
 You can pass a per-request max age parameter to req.freshness, through other prerender plugins, to customize the cache freshness (set to one month by default):
 
-Exemple:
+Example:
 ```javascript
 // in another plugin placed before prerender-level-cache
 module.exports = {

--- a/lib/levelCache.js
+++ b/lib/levelCache.js
@@ -16,6 +16,10 @@ module.exports = {
             return next();
         }
 
+        // force a refresh of the cache if the locahost submits a request with the "RefreshCache" user agent
+        if (req.headers['user-agent'] == 'RefreshCache' && req.headers['host'].indexOf('localhost') == 0)
+            return next();
+
         var freshness = req.freshness
         // dont use || to test the freshness as it might disacard 0 values
         if (freshness == null) { freshness = oneMonth }


### PR DESCRIPTION
This feature is very useful for updating the cache when you know that the page has changed, to warm the cache with the new version rather than waiting for the freshness to expire and incurring an increased page load time for the visitor.

Sometimes prerender can take a long time to render a page so it is best if the re-caching is done before a visitor even makes a request to the page.  I use a bash script to re-cache every time I update my site.
